### PR TITLE
Add Liquid Time-Constant RL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Liquet-RL
+
+This repository contains a minimal reinforcement learning agent that uses a **Liquid Time-Constant (LTC) neural network** as the recurrent core of an actor-critic policy. The example is designed for the classic `CartPole-v1` environment from `gymnasium` and demonstrates how to implement an LTC cell and train it end-to-end with policy gradients.
+
+## Requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the example
+
+```bash
+python train.py
+```
+
+Training prints the episodic reward every few episodes. The implementation is intentionally compact so it can serve as a starting point for further experimentation.

--- a/actor_critic.py
+++ b/actor_critic.py
@@ -1,0 +1,23 @@
+import torch
+from torch import nn
+from ltc import LTCCell
+
+
+class ActorCritic(nn.Module):
+    """Simple actor-critic network using an LTC cell."""
+
+    def __init__(self, obs_size: int, action_size: int, hidden_size: int = 64, dt: float = 0.02):
+        super().__init__()
+        self.ltc = LTCCell(obs_size, hidden_size, dt)
+        self.actor = nn.Linear(hidden_size, action_size)
+        self.critic = nn.Linear(hidden_size, 1)
+
+    @property
+    def hidden_size(self) -> int:
+        return self.ltc.hidden_size
+
+    def forward(self, x: torch.Tensor, h: torch.Tensor):
+        h = self.ltc(x, h)
+        logits = self.actor(h)
+        value = self.critic(h)
+        return logits, value.squeeze(-1), h

--- a/ltc.py
+++ b/ltc.py
@@ -1,0 +1,39 @@
+import torch
+from torch import nn
+
+
+class LTCCell(nn.Module):
+    """Liquid Time-Constant recurrent cell."""
+
+    def __init__(self, input_size: int, hidden_size: int, dt: float = 0.02):
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.dt = dt
+
+        self.weight_ih = nn.Parameter(torch.Tensor(hidden_size, input_size))
+        self.weight_hh = nn.Parameter(torch.Tensor(hidden_size, hidden_size))
+        self.bias = nn.Parameter(torch.zeros(hidden_size))
+        # Time constants are positive. We store them in log-space for stability.
+        self.log_tau = nn.Parameter(torch.zeros(hidden_size))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.xavier_uniform_(self.weight_ih)
+        nn.init.constant_(self.weight_hh, 0.0)
+        nn.init.constant_(self.bias, 0.0)
+        nn.init.constant_(self.log_tau, 1.0)
+
+    def forward(self, x: torch.Tensor, h: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the LTC cell.
+
+        Args:
+            x: input tensor of shape ``(batch, input_size)``
+            h: previous hidden state of shape ``(batch, hidden_size)``
+        Returns:
+            Next hidden state tensor of shape ``(batch, hidden_size)``
+        """
+        tau = torch.relu(self.log_tau) + 1e-3  # ensure positivity
+        x_dot = -h / tau + x @ self.weight_ih.T + h @ self.weight_hh.T + self.bias
+        h_next = h + self.dt * x_dot
+        return h_next

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gymnasium
+torch

--- a/train.py
+++ b/train.py
@@ -1,0 +1,58 @@
+import torch
+import torch.nn.functional as F
+import gymnasium as gym
+from actor_critic import ActorCritic
+
+
+def train(num_episodes: int = 300, gamma: float = 0.99):
+    env = gym.make("CartPole-v1")
+    obs_size = env.observation_space.shape[0]
+    action_size = env.action_space.n
+
+    model = ActorCritic(obs_size, action_size)
+    optimizer = torch.optim.Adam(model.parameters(), lr=3e-4)
+
+    for episode in range(1, num_episodes + 1):
+        obs, _ = env.reset()
+        h = torch.zeros(1, model.hidden_size)
+        log_probs = []
+        values = []
+        rewards = []
+        done = False
+        while not done:
+            obs_t = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
+            logits, value, h = model(obs_t, h)
+            dist = torch.distributions.Categorical(logits=logits)
+            action = dist.sample()
+            log_probs.append(dist.log_prob(action))
+            values.append(value)
+            obs, reward, terminated, truncated, _ = env.step(action.item())
+            done = terminated or truncated
+            rewards.append(reward)
+
+        returns = []
+        R = 0.0
+        for r in reversed(rewards):
+            R = r + gamma * R
+            returns.insert(0, R)
+        returns = torch.tensor(returns, dtype=torch.float32)
+        values = torch.cat(values)
+        log_probs = torch.stack(log_probs)
+        advantage = returns - values.detach()
+
+        policy_loss = -(log_probs * advantage).mean()
+        value_loss = F.mse_loss(values, returns)
+        loss = policy_loss + 0.5 * value_loss
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        if episode % 10 == 0:
+            print(f"Episode {episode}: reward={sum(rewards):.1f} loss={loss.item():.3f}")
+
+    env.close()
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary
- add minimal LTC cell implementation
- add actor-critic network using LTC
- provide CartPole training script with LTC policy
- include requirements and update README

## Testing
- `python train.py` (runs training and prints episodic rewards)


------
https://chatgpt.com/codex/tasks/task_e_684993d3738083329be0ff1f2ab34514