### PR TITLE
Fix actor input pipeline for Dreamer example

### DIFF
--- a/dreamer/actor.py
+++ b/dreamer/actor.py
@@ -84,7 +84,7 @@ class Actor(nn.Module):
         if deterministic:
             action = dist.mean if hasattr(dist, "mean") else dist.probs.argmax(-1)
         else:
-            action = dist.rsample() if hasattr(dist, "rsample") else dist.sample()
+            action = dist.rsample() if getattr(dist, "has_rsample", False) else dist.sample()
 
         log_prob = dist.log_prob(action)
         # Ensure correct shape for multi‑dimensional continuous actions

--- a/dreamer/main.py
+++ b/dreamer/main.py
@@ -70,19 +70,32 @@ learner = DreamerLearner(
 # 4.  Training loop
 # ------------------------------------------------------------------- #
 obs, _ = env.reset()
+h, z = wm.init_state(batch_size=1, device=device)
+prev_act = torch.zeros(1, act_dim, device=device)
 episode_return = 0; step = 0
 while step < 1_000_000:
     # ----- collect real step ----- #
-    feat = torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+    obs_t = torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+    h, z, feat = wm.step(obs_t, prev_act, h, z)
     action, _, _ = actor(feat, deterministic=False)
-    act_np = action.squeeze(0).cpu().numpy()
+    if cfg["action_discrete"]:
+        act_idx = int(action.item())
+        act_np = act_idx
+        prev_act = torch.zeros(1, act_dim, device=device)
+        prev_act[0, act_idx] = 1.0
+    else:
+        act_np = action.squeeze(0).cpu().numpy()
+        prev_act = action.detach()
+
     next_obs, reward, done, truncated, _ = env.step(act_np)
-    replay.add(obs, act_np, reward, done)
+    replay.add(obs, prev_act.squeeze(0).cpu().numpy(), reward, done)
     obs, episode_return = (next_obs, episode_return + reward)
 
     if done or truncated:
         print(f"Episode return {episode_return:.1f}")
         obs, _ = env.reset(); episode_return = 0
+        h, z = wm.init_state(batch_size=1, device=device)
+        prev_act.zero_()
 
     # ----- learner updates ----- #
     if replay.ready(cfg["batch_size"]):

--- a/dreamer/model.py
+++ b/dreamer/model.py
@@ -86,3 +86,22 @@ class DreamerModel(nn.Module):
         obs_pred = self.obs_decoder(feat)
         rew_pred = self.reward_decoder(feat)
         return priors, posts, obs_pred, rew_pred, feat
+
+    def init_state(self, batch_size: int = 1, device: torch.device | None = None):
+        """Return zero-initialised deterministic and stochastic states."""
+        device = device or next(self.parameters()).device
+        h = torch.zeros(batch_size, self.rssm.deter_dim, device=device)
+        z = torch.zeros(batch_size, self.rssm.stoch_dim, device=device)
+        return h, z
+
+    def step(self, obs: torch.Tensor, act: torch.Tensor,
+             h: torch.Tensor, z: torch.Tensor):
+        """Single RSSM update used during environment interaction."""
+        obs_emb = self.encoder(obs)
+        x = torch.cat([act, z], -1)
+        h = self.rssm.ltc(x, h)
+        stats = self.rssm.post(torch.cat([h, obs_emb], -1))
+        post = self.rssm._dist(stats)
+        z = post.rsample()
+        feat = torch.cat([h, z], -1)
+        return h, z, feat


### PR DESCRIPTION
## Summary
- add stateful `step` helper to `DreamerModel`
- update main loop to use world model state and one‑hot actions
- fix stochastic actor's sampling for discrete actions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `timeout 15 python dreamer/main.py --configs base debug cartpole` *(fails: ValueError: empty range for randrange)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7ad290c8332ac0053ec80a05545